### PR TITLE
C0+C1 の送信が複数の tcp パケットに分割されないようにバッファしてから write する

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,9 @@
-module github.com/yutopp/go-rtmp
+module github.com/dwango-nfc/go-rtmp
 
 go 1.13
 
 require (
 	github.com/fortytw2/leaktest v1.2.0
-	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-multierror v1.1.0
 	github.com/mitchellh/mapstructure v1.4.1
 	github.com/pkg/errors v0.9.1
@@ -12,5 +11,5 @@ require (
 	github.com/stretchr/testify v1.8.1
 	github.com/yutopp/go-amf0 v0.1.0
 	github.com/yutopp/go-flv v0.3.0
-	golang.org/x/sys v0.3.0 // indirect
+	github.com/yutopp/go-rtmp v0.0.4
 )

--- a/go.sum
+++ b/go.sum
@@ -24,10 +24,14 @@ github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
+github.com/yutopp/go-amf0 v0.0.0-20180803120851-48851794bb1f/go.mod h1:miopb3mUO8ynCPmYD04SZ0JCMFsBt0eOdAuQ6HHHQ6Q=
 github.com/yutopp/go-amf0 v0.1.0 h1:a3UeBZG7nRF0zfvmPn2iAfNo1RGzUpHz1VyJD2oGrik=
 github.com/yutopp/go-amf0 v0.1.0/go.mod h1:QzDOBr9RV6sQh6E5GFEJROZbU0iQKijORBmprkb3FIk=
+github.com/yutopp/go-flv v0.2.0/go.mod h1:xe1MPrWcfQfYeBT7E5WAF0zvKUyf1hmSpesDjBoUV4E=
 github.com/yutopp/go-flv v0.3.0 h1:zkjsXqxfkwnrtPNvicxCKkaJnvwzf7kOfL/OUERP6LQ=
 github.com/yutopp/go-flv v0.3.0/go.mod h1:pAlHPSVRMv5aCUKmGOS/dZn/ooTgnc09qOPmiUNMubs=
+github.com/yutopp/go-rtmp v0.0.4 h1:zMnb4YflIi5x9ThvnIjo9FsaUtfh5lzySjGJyXO1qqA=
+github.com/yutopp/go-rtmp v0.0.4/go.mod h1:JOa0EiIhwVeDrDGYQT4dlfAHslOhKuNP4nluYqTDF6w=
 golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.3.0 h1:w8ZOecv6NaNa/zC8944JTU3vz4u6Lagfk4RPQxv92NQ=
 golang.org/x/sys v0.3.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/handshake/encoder.go
+++ b/handshake/encoder.go
@@ -22,52 +22,37 @@ func NewEncoder(w io.Writer) *Encoder {
 	}
 }
 
-func (e *Encoder) EncodeS0C0(h *S0C0) error {
-	buf := [1]byte{byte(*h)}
-
-	_, err := e.w.Write(buf[:])
-	if err != nil {
+func (e *Encoder) EncodeS1C1(v0 S0C0, v1 *S1C1) error {
+	memory := [1537]byte{}
+	view := memory[0:0]
+	view = append(view, byte(v0))
+	view = appendS1C1(view, v1)
+	if _, err := e.w.Write(view[:]); err != nil {
 		return err
 	}
-
-	return nil
-}
-
-func (e *Encoder) EncodeS1C1(h *S1C1) error {
-	buf := [4]byte{}
-
-	binary.BigEndian.PutUint32(buf[:], h.Time)
-	if _, err := e.w.Write(buf[:]); err != nil {
-		return err
-	}
-
-	if _, err := e.w.Write(h.Version[:]); err != nil {
-		return err
-	}
-
-	if _, err := e.w.Write(h.Random[:]); err != nil {
-		return err
-	}
-
 	return nil
 }
 
 func (e *Encoder) EncodeS2C2(h *S2C2) error {
-	buf := [4]byte{}
-
-	binary.BigEndian.PutUint32(buf[:], h.Time)
-	if _, err := e.w.Write(buf[:]); err != nil {
+	memory := [1536]byte{}
+	view := memory[0:0]
+	view = appendS2C2(view, h)
+	if _, err := e.w.Write(view[:]); err != nil {
 		return err
 	}
-
-	binary.BigEndian.PutUint32(buf[:], h.Time2)
-	if _, err := e.w.Write(buf[:]); err != nil {
-		return err
-	}
-
-	if _, err := e.w.Write(h.Random[:]); err != nil {
-		return err
-	}
-
 	return nil
+}
+
+func appendS1C1(out []byte, h *S1C1) []byte {
+	out = binary.BigEndian.AppendUint32(out, h.Time)
+	out = append(out, h.Version[:]...)
+	out = append(out, h.Random[:]...)
+	return out
+}
+
+func appendS2C2(out []byte, h *S2C2) []byte {
+	out = binary.BigEndian.AppendUint32(out, h.Time)
+	out = binary.BigEndian.AppendUint32(out, h.Time2)
+	out = append(out, h.Random[:]...)
+	return out
 }

--- a/handshake/handshake.go
+++ b/handshake/handshake.go
@@ -52,13 +52,8 @@ func HandshakeWithClient(r io.Reader, w io.Writer, config *Config) error {
 
 	// TODO: check c0 RTMP version
 
-	// Send S0
+	// Send S0+S1
 	s0 := S0C0(RTMPVersion)
-	if err := e.EncodeS0C0(&s0); err != nil {
-		return err
-	}
-
-	// Send S1
 	s1 := S1C1{
 		Time: uint32(timeNow().UnixNano() / int64(time.Millisecond)),
 	}
@@ -66,7 +61,7 @@ func HandshakeWithClient(r io.Reader, w io.Writer, config *Config) error {
 	if _, err := rand.Read(s1.Random[:]); err != nil { // Random Seq
 		return err
 	}
-	if err := e.EncodeS1C1(&s1); err != nil {
+	if err := e.EncodeS1C1(s0, &s1); err != nil {
 		return err
 	}
 
@@ -110,13 +105,8 @@ func HandshakeWithServer(r io.Reader, w io.Writer, config *Config) error {
 	d := NewDecoder(r)
 	e := NewEncoder(w)
 
-	// Send C0
+	// Send C0+C1
 	c0 := S0C0(RTMPVersion)
-	if err := e.EncodeS0C0(&c0); err != nil {
-		return errors.Wrap(err, "Failed to encode c0")
-	}
-
-	// Send C1
 	c1 := S1C1{
 		Time: uint32(timeNow().UnixNano() / int64(time.Millisecond)),
 	}
@@ -124,7 +114,7 @@ func HandshakeWithServer(r io.Reader, w io.Writer, config *Config) error {
 	if _, err := rand.Read(c1.Random[:]); err != nil { // Random Seq
 		return err
 	}
-	if err := e.EncodeS1C1(&c1); err != nil {
+	if err := e.EncodeS1C1(c0, &c1); err != nil {
 		return errors.Wrap(err, "Failed to encode c1")
 	}
 


### PR DESCRIPTION
↓この問題に対処
https://github.com/dwango-nfc/live-stream-mediator/issues/28
